### PR TITLE
Add missing include for GCC

### DIFF
--- a/util/drakeMexUtil.cpp
+++ b/util/drakeMexUtil.cpp
@@ -1,4 +1,5 @@
 #include "drakeMexUtil.h"
+#include <stdexcept>
 
 using namespace std;
 using namespace Eigen;


### PR DESCRIPTION
I was also able to compile without this include, but it clearly should be there so the build server is right to complain. Hope this will be the only error on GCC.