### PR TITLE
Fix test failure

### DIFF
--- a/drake/systems/controllers/instantaneousQPControllermex.cpp
+++ b/drake/systems/controllers/instantaneousQPControllermex.cpp
@@ -24,8 +24,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   if (nlhs < 1)
     mexErrMsgTxt("take at least one output... please.");
 
-  double* pr;
-
   // first get the ptr back from matlab
   InstantaneousQPController *controller = (InstantaneousQPController*) getDrakeMexPointer(prhs[0]);
 

--- a/drake/systems/plants/RigidBody.cpp
+++ b/drake/systems/plants/RigidBody.cpp
@@ -1,7 +1,6 @@
 
 #include "RigidBody.h"
 #include <stdexcept>
-#include <numeric>
 
 using namespace std;
 using namespace Eigen;
@@ -72,13 +71,8 @@ bool RigidBody::appendCollisionElementIdsFromThisBody(const string& group_name, 
 
 bool RigidBody::appendCollisionElementIdsFromThisBody(vector<DrakeCollision::ElementId>& ids) const
 {
-  auto add_element_count = [](size_t count, const pair<string, vector<DrakeCollision::ElementId>>& group) {return count + group.second.size(); };
-  size_t num_elements = accumulate(collision_element_groups.begin(), collision_element_groups.end(), size_t(0), add_element_count);
-
-  ids.reserve(ids.size() + num_elements);
-  for (const auto& group : collision_element_groups) {
-    ids.insert(ids.end(), group.second.begin(), group.second.end());
-  }
+  ids.reserve(ids.size() + collision_element_ids.size());
+  ids.insert(ids.end(), collision_element_ids.begin(), collision_element_ids.end());
   return true;
 }
 

--- a/drake/systems/plants/RigidBody.h
+++ b/drake/systems/plants/RigidBody.h
@@ -69,6 +69,7 @@ public:
 
   DrakeShapes::VectorOfVisualElements visual_elements;
 
+  std::vector< DrakeCollision::ElementId > collision_element_ids;
   std::map< std::string, std::vector<DrakeCollision::ElementId> > collision_element_groups;
 
   Eigen::Matrix3Xd contact_pts;

--- a/drake/systems/plants/RigidBodyTree.h
+++ b/drake/systems/plants/RigidBodyTree.h
@@ -358,17 +358,19 @@ public:
   template <class UnaryPredicate>
   void removeCollisionGroupsIf(UnaryPredicate test) {
     for (const auto& body_ptr : bodies) {
-      std::vector<std::string> to_delete;
+      std::vector<std::string> names_of_groups_to_delete;
       for (const auto &group : body_ptr->collision_element_groups) {
         const std::string &group_name = group.first;
         if (test(group_name)) {
+          auto& ids = body_ptr->collision_element_ids;
           for (const auto& id : group.second) {
+            ids.erase(std::find(ids.begin(), ids.end(), id));
             collision_model->removeElement(id);
           }
-          to_delete.push_back(group_name);
+          names_of_groups_to_delete.push_back(group_name);
         }
       }
-      for (const auto& group_name : to_delete) {
+      for (const auto& group_name : names_of_groups_to_delete) {
         body_ptr->collision_element_groups.erase(group_name);
       }
     }


### PR DESCRIPTION
Revert deleting the std::vector of CollisionIDs in RigidBody that lives alongside the collision groups.

(also delete an unused double* in instantaneousQPControllermex.cpp)